### PR TITLE
Swapping Oxford stringency source to legacy data

### DIFF
--- a/R/get_country_overlays.R
+++ b/R/get_country_overlays.R
@@ -63,7 +63,7 @@ function(rfunctions.dir, df_ncov) {
     pivot_longer(cols=c("inc_ma7", "mort_ma7"), names_to="cases_death_type", values_to="cases_death_value")
 
   #Get Policy Stringency Data
-  df.oxford.raw <- data.table::fread("https://raw.githubusercontent.com/OxCGRT/covid-policy-tracker/master/data/OxCGRT_latest.csv")
+  df.oxford.raw <- data.table::fread("https://raw.githubusercontent.com/OxCGRT/covid-policy-tracker-legacy/main/legacy_data_202207/OxCGRT_latest.csv")
   df.oxford <- df.oxford.raw %>%
     rename_all(tolower) %>%
     filter(jurisdiction == "NAT_TOTAL") %>%


### PR DESCRIPTION
- See Ox announcement: https://github.com/OxCGRT/covid-policy-tracker/commit/a6838a95e14fc71c1f6a5a948b8093ad24f800d9
- Dead link broke pipeline