### PR TITLE
chore[dep]: Updating one more dependencies, missed from last change

### DIFF
--- a/.github/workflows/automated_dashboard_update.yaml
+++ b/.github/workflows/automated_dashboard_update.yaml
@@ -41,7 +41,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: "master"
       - uses: r-lib/actions/setup-renv@v2


### PR DESCRIPTION
- One more dependency update needed to get rid of nodejs warnings.